### PR TITLE
loading page when cliked play and fixing some bugs

### DIFF
--- a/game.html
+++ b/game.html
@@ -28,6 +28,17 @@
       position: relative;
       width: 1035px;
       height: 596px;
+      opacity: 0;
+      transition: opacity 0.4s ease;
+    }
+
+    @keyframes loadLogoFloat {
+      0%, 100% { transform: translateY(0px); }
+      50%       { transform: translateY(-8px); }
+    }
+    @keyframes loadPulse {
+      0%, 100% { opacity: 1; }
+      50%       { opacity: 0.3; }
     }
 
     #gameShell canvas {
@@ -332,6 +343,21 @@
   </style>
 </head>
 <body>
+  <div id="loadingScreen" style="
+      position: fixed; inset: 0; z-index: 999;
+      background: #0a0a0e;
+      display: flex; flex-direction: column;
+      align-items: center; justify-content: center;
+      transition: opacity 0.5s ease;
+    ">
+      <img src="assets/logo.png" style="width: 400px; image-rendering: pixelated;
+        animation: loadLogoFloat 1.5s ease-in-out infinite;" />
+      <div style="margin-top: 32px; font-family: 'PixelFont', sans-serif;
+        font-size: 22px; color: #FFD700; letter-spacing: 4px;
+        animation: loadPulse 1s ease-in-out infinite;">LOADING...</div>
+    </div>
+
+  ...
   <div id="gameShell">
     <div id="borderOverlay">
       <img id="borderLeft" src="assets/map1/border/leftBorder.png" alt="Left border" />
@@ -845,6 +871,7 @@
     let successFlash = { timer: 0, x: 0, y: 0 };
 
     const gameShell = document.getElementById("gameShell");
+    const loadStartTime = Date.now();
 
     function refreshTimerOverlay() {
       if (!timerBoxImage || !timerBoxImage.naturalWidth) return;
@@ -1600,24 +1627,32 @@
           onWordCompleted();
         }
       } else if (hasRemainingLetter(block.letter)) {
-        TargetWord.onLetterHit(block.letter, false);
+        // TargetWord.onLetterHit(block.letter, false);
+       if (window.TargetWord?.state) {
+          window.TargetWord.state.lives = Math.max(0, window.TargetWord.state.lives - 1);
+        }
         markTargetWordDirty();
         queueBlockAnimation(block, null, 20);
+        checkGameOverForPlayer();
       } else {
-        TargetWord.onLetterHit(block.letter, false);
+        // TargetWord.onLetterHit(block.letter, false);
+       if (window.TargetWord?.state) {
+          window.TargetWord.state.lives = Math.max(0, window.TargetWord.state.lives - 1);
+        }
         markTargetWordDirty();
         block.wrongFlash = 24;
         queueBlockAnimation(block, "fall", 18);
+        checkGameOverForPlayer();
       }
       checkGameOverForPlayer();
     }
 
     function handleMissedShot() {
-      if (gameOver) return;
-      if (window.TargetWord && typeof TargetWord.recordMiss === "function") {
-        TargetWord.recordMiss();
-        checkGameOverForPlayer();
-      }
+      // if (gameOver) return;
+      // if (window.TargetWord && typeof TargetWord.recordMiss === "function") {
+      //   TargetWord.recordMiss();
+      //   checkGameOverForPlayer();
+      // }
     }
 
     function checkGameOverForPlayer() {
@@ -1636,9 +1671,13 @@
     }
 
     function handleGameOver(reason) {
-      initPause();
+      hidePauseOverlay();
       if (gameOver) return;
       gameOver = true;
+
+      const pauseUI = document.getElementById('pauseUI');
+      if (pauseUI) pauseUI.style.display = 'none';
+
       if (typeof bgMusic !== 'undefined') bgMusic.pause();
       playGameOverSfx();
       stopTickingSfx();
@@ -1748,8 +1787,14 @@
     function restartGame() {
       if (!window.TargetWord) return;
       stopTickingSfx();
-      initPause();
-      if (typeof bgMusic !== 'undefined') bgMusic.play().catch(() => {});
+      hidePauseOverlay();
+
+      const pauseUI = document.getElementById('pauseUI');
+      if (pauseUI) pauseUI.style.display = '';
+
+      if (typeof bgMusic !== 'undefined') 
+      bgMusic.currentTime = 0;
+      bgMusic.play().catch(() => {});
       TargetWord.resetGameProgress();
       currentWord = TargetWord.state.word;
       cannonBalls.length = 0;
@@ -1788,7 +1833,10 @@
     function fireCannon() {
       if (gameOver || gamePaused) return;
       const ammoState = window.TargetWord?.state;
-      if (ammoState && ammoState.ammo <= 0) return;
+      if (ammoState) {
+        ammoState.ammo = Math.max(0, ammoState.ammo - 1);
+        checkGameOverForPlayer();
+      }
 
       playFireSfx();
 
@@ -2328,8 +2376,23 @@
         generateLetterBlocks();
         persistGameState();
         startAutoSave();
-        render();
-        requestAnimationFrame(animate);
+
+        // Fade out loading, fade in game
+        const loading = document.getElementById('loadingScreen');
+        const revealGame = () => {
+          if (loading) {
+            loading.style.opacity = '0';
+            setTimeout(() => { loading.style.display = 'none'; }, 500);
+          }
+          document.getElementById('gameShell').style.opacity = '1';
+          render();
+          requestAnimationFrame(animate);
+        };
+
+        // Enforce minimum 1.5s loading screen display
+        const elapsed  = Date.now() - loadStartTime;
+        const remaining = Math.max(0, 1500 - elapsed);
+        setTimeout(revealGame, remaining);
       }
 
       if (window.TargetWord) {


### PR DESCRIPTION
## Fix: Game Polish, Loading Screen & Gameplay Mechanics (`game.html`)

### Overview
This PR addresses multiple gameplay, audio, and UX issues discovered during testing.

---

### 1. Loading Screen (ported from `tutorial.html`)

Added the same loading screen pattern already shipping in `tutorial.html`:
- `#loadingScreen` div placed outside `#gameShell` with `position: fixed; z-index: 999`
- `#gameShell` starts at `opacity: 0` and fades in after assets load
- `loadStartTime = Date.now()` enforces a minimum 1.5s display so the logo animation is always visible
- Prevents missing letter blocks caused by the canvas rendering before images finish loading

```js
// In finalizeStart():
const elapsed   = Date.now() - loadStartTime;
const remaining = Math.max(0, 1500 - elapsed);
setTimeout(revealGame, remaining);
```

---

### 2. Pause Button Fixes

**`initPause()` was being called multiple times** — it was incorrectly placed inside `handleGameOver()` and `restartGame()`, re-registering all click listeners on every game over and restart. Fixed by replacing both with `hidePauseOverlay()`.

`initPause()` is now called exactly once at the bottom of the inline script.

**Pause button hidden on game over:**
```js
// In handleGameOver():
const pauseUI = document.getElementById('pauseUI');
if (pauseUI) pauseUI.style.display = 'none';

// In restartGame():
if (pauseUI) pauseUI.style.display = '';
```

---

### 3. Music Restarts from Beginning on Restart

```js
// In restartGame():
bgMusic.currentTime = 0; // ← resets track to beginning
bgMusic.play().catch(() => {});
```

---

### 4. Ammo & Lives Logic Rewrite

Previous behavior was inconsistent — missed shots, wrong hits, and firing all mixed up lives and ammo deductions in unpredictable ways.

**New behavior:**

| Action | Ammo | Lives |
|---|---|---|
| Fire cannon | −1 | no change |
| Ball misses (out of bounds) | no change | no change |
| Hit wrong letter / distractor | no change | −1 |
| Hit correct letter | no change | no change |

**Ammo deducted in `fireCannon()`:**
```js
if (ammoState) {
  ammoState.ammo = Math.max(0, ammoState.ammo - 1);
  checkGameOverForPlayer();
}
```

**`handleMissedShot()` is now a no-op:**
```js
function handleMissedShot() {
  // Ammo already deducted in fireCannon()
  // No lives penalty for missing
}
```

**Wrong hit branches deduct lives only:**
```js
if (window.TargetWord?.state) {
  window.TargetWord.state.lives = Math.max(0, window.TargetWord.state.lives - 1);
}
checkGameOverForPlayer();
```

---

### 5. Ticking SFX Stops on New Round

`stopTickingSfx()` added to `onWordCompleted()` so the ticking audio doesn't carry over into the next round when the player completes a word with ≤10s remaining.

```js
function onWordCompleted() {
  stopTickingSfx(); // ← added
  updateThemeForRound(currentRound);
  // ...
}
```

---

### Files changed
| File | Change |
|---|---|
| `game.html` | Loading screen, pause fix, music restart, ammo/lives logic, ticking fix, pause button visibility |
| `js/pause.js` | `initPause()` called once only, removed from game over / restart flow |
| `js/sfx.js` | `stopTickingSfx()` exposed and called on round complete |
| `js/music.js` | `window.bgMusic` alias added for cross-file access |